### PR TITLE
bug (password): Fix password creation on signup

### DIFF
--- a/apps/authentication/forms.py
+++ b/apps/authentication/forms.py
@@ -22,11 +22,20 @@ class RegisterForm(forms.ModelForm):
 
     def clean_password2(self):
         # Check that the two password entries match
-        password1 = self.cleaned_data.get("password1")
+        password1 = self.cleaned_data.get("password")
         password2 = self.cleaned_data.get("password2")
         if password1 and password2 and password1 != password2:
             raise forms.ValidationError("Passwords don't match")
         return password2
+    
+    def save(self, commit=True):
+        # Save the provided password in hashed format
+        user = super(RegisterForm, self).save(commit=False)
+        user.set_password(self.cleaned_data["password"])
+        if commit:
+            user.save()
+        return user
+    
 
 
 class UserAdminCreationForm(forms.ModelForm):

--- a/apps/authentication/views.py
+++ b/apps/authentication/views.py
@@ -18,6 +18,11 @@ class RegistrationView(g.CreateView):
     template_name= 'signup.html'
     success_url = '/'
 
+    def form_valid(self, form):
+        instance = form.save(commit=False)
+        print(form.data)
+        return super(RegistrationView, self).form_valid(form)
+
 
 class ProfileView(m.LoginRequiredMixin, g.DetailView):
     model = Profile

--- a/apps/questions/tests/test_models.py
+++ b/apps/questions/tests/test_models.py
@@ -1,11 +1,13 @@
 from django.test import TestCase
-from ..models import Question
+from ..models import Question, Tag
 from apps.authentication.models import User
+from django.db.utils import IntegrityError
 
 
 class TestQuestionModels(TestCase):
     def setUp(self):
         self.model  = Question()
+        self.tagModel = Tag()
 
     def test_get_absolute_url(self):
         User.objects.create_user(email='user@mail.com', password='#pho3nix9q')
@@ -15,6 +17,17 @@ class TestQuestionModels(TestCase):
 
         self.assertEqual(qs.get_absolute_url(), f"/questions/{qs.question_slug}/view/")
         self.assertEqual(qs.__str__(), qs.title)
+
+    def test_creating_an_existing_tag_fails(self):
+        with self.assertRaises(IntegrityError) : 
+            Tag.objects.create(name="angular")
+            Tag.objects.create(name="angular")
+
+    def test_creating_tag_without_name_fails(self):
+        with self.assertRaises(IntegrityError):
+            Tag.objects.create(name=None)
+
+
 
     
 


### PR DESCRIPTION
#### What does this Pr do?
- Adds an implementation to fix setting of passwords when a user successfully registers instead of an empty string. 

#### Description of the task
- Whenever a user registers, there passwords are not set as it should be thus preventing them from accessing their account. This has since been fixed. 

[Fixes #167937749]